### PR TITLE
Include `String` type in panic `payload` casting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,5 @@ jobs:
         run: cargo -Zminimal-versions generate-lockfile
       - uses: dtolnay/rust-toolchain@1.74.0
       - name: Cargo check
-        run: cargo check --workspace --all-targets
+        # skip the tests, which require the lazy_cell feature from Rust 1.80
+        run: cargo check --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["log", "panic"]
 rust-version = "1.74"
 
 [dependencies]
-log = "0.4"
+log = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Log panics to the `log` macro as error"
 include = ["src", "LICENSE"]
 categories = ["development-tools", "development-tools::debugging"] # https://crates.io/category_slugs
 keywords = ["log", "panic"]
+rust-version = "1.74"
 
 [dependencies]
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ Call this somewhere at the start of your program (after initializing your logger
 
 ```rust
 use panic_log::Configuration;
-[...]
+// ...
 panic_log::initialize_hook(Configuration::default());
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,12 @@ pub fn initialize_hook(config: Configuration) {
         } else {
             "<unknown location>".to_owned()
         };
-        let message = info.payload().downcast_ref::<&str>().unwrap_or(&"");
+        let message = info
+            .payload()
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| info.payload().downcast_ref::<String>().map(|s| s.as_str()))
+            .unwrap_or("<message is not a string>");
 
         let backtrace = if config.force_capture {
             backtrace::Backtrace::force_capture()

--- a/tests/test_hook.rs
+++ b/tests/test_hook.rs
@@ -6,25 +6,41 @@ use std::{
 
 use panic_log::{initialize_hook, Configuration};
 
+// The test binary runs all tests in parallel by default; this lets multiple tests overwrite the
+// panic hook concurrently and cause spurious failure.
+static SERIAL_TEST: Mutex<()> = Mutex::new(());
+
 #[test]
 #[should_panic]
 fn test() {
+    let _serial = SERIAL_TEST.lock().unwrap();
+
     initialize_hook(Configuration::default());
+
+    // Drop the lock to not poison it
+    drop(_serial);
     panic!("Test");
 }
 
 #[test]
 #[should_panic]
 fn test_forced_trace() {
+    let _serial = SERIAL_TEST.lock().unwrap();
+
     initialize_hook(Configuration {
         force_capture: true,
         ..Default::default()
     });
+
+    // Drop the lock to not poison it
+    drop(_serial);
     panic!("Test");
 }
 
 #[test]
 fn test_original_hook() {
+    let _serial = SERIAL_TEST.lock().unwrap();
+
     let original_hook = panic::take_hook();
     let ran_hook = Arc::new(Mutex::new(false));
     let ran_hook_copy = Arc::clone(&ran_hook);
@@ -45,6 +61,8 @@ fn test_original_hook() {
 
 #[test]
 fn test_no_original_hook() {
+    let _serial = SERIAL_TEST.lock().unwrap();
+
     let original_hook = panic::take_hook();
     let ran_hook = Arc::new(Mutex::new(false));
     let ran_hook_copy = Arc::clone(&ran_hook);
@@ -65,6 +83,8 @@ fn test_no_original_hook() {
 
 #[test]
 fn test_flush_logger() {
+    let _serial = SERIAL_TEST.lock().unwrap();
+
     struct Logger {
         pub flushed: Arc<Mutex<bool>>,
     }

--- a/tests/test_hook.rs
+++ b/tests/test_hook.rs
@@ -40,7 +40,7 @@ fn test_original_hook() {
     });
     let _ = panic::catch_unwind(|| panic!("Test"));
 
-    assert_eq!(*ran_hook.lock().unwrap(), true);
+    assert!(*ran_hook.lock().unwrap());
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn test_no_original_hook() {
     });
     let _ = panic::catch_unwind(|| panic!("Test"));
 
-    assert_eq!(*ran_hook.lock().unwrap(), false);
+    assert!(!*ran_hook.lock().unwrap());
 }
 
 #[test]


### PR DESCRIPTION
We know from experience - [and the `payload()` docs] - that the returned payload can be a `&'static str` or `String`, but we only downcast the former meaning that any owned (typically because of being `Debug`-formatted) error messages are not included in the panic log. Add the cast to include them.

Note that Rust 1.91 (slightly more than 2 months old at the time of writing) added this cast to the `PanicHookInfo` type directly: https://doc.rust-lang.org/stable/std/panic/struct.PanicHookInfo.html#method.payload_as_str

[and the `payload()` docs]: https://doc.rust-lang.org/stable/std/panic/struct.PanicHookInfo.html#method.payload
